### PR TITLE
Handle unpacking of our own date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,18 @@ NSDictionary *unpackedDictionary = [MessagePack unpackData:messagePackData];
 ### Supported native types:
 - `NSArray`
 - `NSData`
-- `NSDate` (using [MessagePack-timestamps](https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type))
+- `NSDate` (using [MessagePack timestamps](https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type))
 - `NSDictionary`
 - `NSNumber` (`boolean`, `u64`, `i64`, `float32/64`)
 - `NSString`
 
 ## Extension support
 
-The library supports [MessagePack-timestamps](https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type),
+The library supports [MessagePack timestamps](https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type),
 and will return an `NSDate`-object whenever one is encountered. When serializing, any `NSDate`-objects will also be
-serialized as native MessagePack-timestamps.
+serialized as native MessagePack timestamps.
 
-You can add native serialization for your own classes by subclassing `MessagePackExtension`.
+You can add native serialization for your own classes by conforming to protocol `MessagePackSerializable` and register it like this:
+```c
+[MessagePack registerClass:Person.class forExtensionType:14];
+```

--- a/msgpack-objc/MessagePack.h
+++ b/msgpack-objc/MessagePack.h
@@ -8,18 +8,21 @@
 
 #import <Foundation/Foundation.h>
 
+@protocol MessagePackSerializable
+
+@required
+- (instancetype)initWithMessagePackData:(NSData *)data extensionType:(int8_t)type;
+
+@optional
+- (NSData *)messagePackData;
+
+@end
+
 @interface MessagePack : NSObject
 
 + (id)unpackData:(NSData *)data;
 + (NSData *)packObject:(id)object;
 
-@end
-
-@interface MessagePackExtension : NSObject
-
-+ (instancetype)extensionWithType:(int8_t)type data:(NSData *)data;
-
-@property (nonatomic, readonly) int8_t type;
-@property (nonatomic, readonly) NSData *data;
++ (void)registerClass:(Class)class forExtensionType:(int8_t)extensionType;
 
 @end

--- a/msgpack-objc/MessagePack.m
+++ b/msgpack-objc/MessagePack.m
@@ -9,16 +9,33 @@
 #import "MessagePack.h"
 #import <msgpack-c/msgpack.h>
 
-@interface TimestampExtension : MessagePackExtension
-
-- (instancetype)initWithDate:(NSDate *)date;
-- (NSDate *)date;
+@interface NSDate (TimestampSerializable) <MessagePackSerializable>
 
 @end
 
 @implementation MessagePack
 
+static NSDictionary<NSNumber *, Class> *_extensions;
+
++ (void)initialize
+{
+    if (self == [MessagePack self]) {
+        [self registerClass:NSDate.class forExtensionType:-1];
+    }
+}
+
 #pragma mark - Public
+
++ (void)registerClass:(Class)class forExtensionType:(int8_t)extensionType
+{
+    @synchronized (self) {
+        if ([class conformsToProtocol:@protocol(MessagePackSerializable)]) {
+            NSMutableDictionary *mutableExtensions = [NSMutableDictionary dictionaryWithDictionary:_extensions];
+            mutableExtensions[@(extensionType)] = class;
+            _extensions = [mutableExtensions copy];
+        }
+    }
+}
 
 + (id)unpackData:(NSData *)data
 {
@@ -88,15 +105,24 @@ void packObject(id object, msgpack_packer *packer)
         NSData *data = (NSData *)object;
         msgpack_pack_bin(packer, data.length);
         msgpack_pack_bin_body(packer, data.bytes, data.length);
-    } else if ([object isKindOfClass:[NSDate class]]) {
-        TimestampExtension *extension = [[TimestampExtension alloc] initWithDate:object];
-        packObject(extension, packer);
-    } else if ([object isKindOfClass:[MessagePackExtension class]]) {
-        MessagePackExtension *extension = (MessagePackExtension *)object;
-        msgpack_pack_ext(packer, extension.data.length, extension.type);
-        msgpack_pack_ext_body(packer, extension.data.bytes, extension.data.length);
     } else {
-        NSLog(@"msgpack-objc: Skipping object of unkown type: %@", object);
+        // Try to find a registered extension that supports unpacking of this object
+        __block BOOL extensionFound;
+        [_extensions enumerateKeysAndObjectsUsingBlock:^(NSNumber *key, Class class, BOOL *stop) {
+            if ([object isKindOfClass:class] && [object respondsToSelector:@selector(messagePackData)]) {
+                NSData *data = [object messagePackData];
+                if (data) {
+                    msgpack_pack_ext(packer, data.length, key.intValue);
+                    msgpack_pack_ext_body(packer, data.bytes, data.length);
+                    extensionFound = YES;
+                    *stop = YES;
+                }
+            }
+        }];
+        
+        if (!extensionFound) {
+            NSLog(@"msgpack-objc: Skipping object of unkown type: %@", object);
+        }
     }
 }
 
@@ -180,12 +206,12 @@ id objectForMessagePackObject(msgpack_object object)
             return [[NSData alloc] initWithBytes:object.via.bin.ptr length:object.via.bin.size];
 
         case MSGPACK_OBJECT_EXT: {
-            NSData *data = [NSData dataWithBytes:object.via.ext.ptr length:object.via.ext.size];
-            MessagePackExtension *extension = [MessagePackExtension extensionWithType:object.via.ext.type data:data];
-            if ([extension isKindOfClass:TimestampExtension.class]) {
-                return [(TimestampExtension *)extension date];
+            int8_t type = object.via.ext.type;
+            Class class = _extensions[@(type)];
+            if (class) {
+                NSData *data = [NSData dataWithBytes:object.via.ext.ptr length:object.via.ext.size];
+                return [[class alloc] initWithMessagePackData:data extensionType:type];
             }
-            return extension;
         }
 
         case MSGPACK_OBJECT_ARRAY: {
@@ -243,50 +269,54 @@ void reverseBytes(uint8_t *start, int size) {
 
 @end
 
-@implementation MessagePackExtension
+@implementation NSDate (TimestampSerializable)
 
-+ (instancetype)extensionWithType:(int8_t)type data:(NSData *)data
+- (instancetype)initWithMessagePackData:(NSData *)data extensionType:(int8_t)type
 {
-    Class extensionClass = type == -1 ? TimestampExtension.class : self;
-    return [[extensionClass alloc] initWithType:type data:data];
-}
-
-- (instancetype)initWithType:(int8_t)type data:(NSData *)data
-{
-    if (self = [super init]) {
-        _type = type;
-        _data = data;
+    if (type != -1) {
+        return nil;
     }
-    return self;
-}
-
-- (BOOL)isEqual:(id)object
-{
-    if (object == self) {
-        return YES;
+    
+    long long seconds;
+    unsigned long long nanoseconds;
+    
+    switch (data.length) {
+        case sizeof(uint32_t): {
+            uint32_t data32 = CFSwapInt32BigToHost(*(uint32_t *)data.bytes);
+            nanoseconds = 0;
+            seconds = data32;
+            break;
+        }
+        case sizeof(uint64_t): {
+            uint64_t data64 = CFSwapInt64BigToHost(*(uint64_t *)data.bytes);
+            nanoseconds = data64 >> 34;
+            seconds = data64 & 0x00000003ffffffffL;
+            break;
+        }
+        case 12: {
+            if (OSHostByteOrder() == OSLittleEndian) {
+                uint8_t bytes[12];
+                [data getBytes:&bytes[0] length:data.length];
+                reverseBytes(&bytes[0], 12);
+                seconds = *(int64_t *)&bytes[0];
+                nanoseconds = *(uint32_t *)(&bytes[0] + sizeof(int64_t));
+            } else {
+                nanoseconds = *(uint32_t *)data.bytes;
+                seconds = *(int64_t *)(data.bytes + sizeof(uint32_t));
+            }
+            break;
+        }
+        default:
+            [NSException raise:NSInternalInconsistencyException format:@"Encountered unsupported TimeStamp format in MessagePack data. Size is %li bytes but supported sizes are 32, 64 or 96 bits.", (unsigned long)data.length];
     }
-    return [object isKindOfClass:self.class] &&
-    [(MessagePackExtension *)object type] == self.type &&
-    [self.data isEqual:[(MessagePackExtension *)object data]];
+    
+    NSTimeInterval interval = seconds + (nanoseconds / ONE_BILLION);
+    return [self initWithTimeIntervalSince1970:interval];
 }
 
-- (NSUInteger)hash
+- (NSData *)messagePackData
 {
-    return self.data.hash ^ self.type;
-}
-
-- (NSString *)description
-{
-    return [NSString stringWithFormat:@"<%@> (type: %i, length: %lu)", NSStringFromClass(self.class), self.type, (unsigned long)self.data.length];
-}
-
-@end
-
-@implementation TimestampExtension
-
-- (instancetype)initWithDate:(NSDate *)date
-{
-    NSTimeInterval timeInterval = [date timeIntervalSince1970];
+    NSTimeInterval timeInterval = [self timeIntervalSince1970];
     double integral = floor(timeInterval);
     double fractional = timeInterval - integral;
     long long seconds = integral;
@@ -308,7 +338,7 @@ void reverseBytes(uint8_t *start, int size) {
         uint32_t nsec = (uint32_t)nanoseconds;
         int64_t sec = (int64_t)seconds;
         uint8_t bytes[12];
-
+        
         if (OSHostByteOrder() == OSLittleEndian) {
             memcpy(&bytes[0], (int64_t *)&sec, sizeof(sec));
             memcpy(&bytes[0] + sizeof(sec), (uint32_t *)&nsec, sizeof(nsec));
@@ -319,46 +349,7 @@ void reverseBytes(uint8_t *start, int size) {
         }
         data = [NSData dataWithBytes:&bytes[0] length:sizeof(bytes)];
     }
-    return [self initWithType:-1 data:data];
-}
-
-- (NSDate *)date
-{
-    long long seconds;
-    unsigned long long nanoseconds;
-
-    switch (self.data.length) {
-        case sizeof(uint32_t): {
-            uint32_t data32 = CFSwapInt32BigToHost(*(uint32_t *)self.data.bytes);
-            nanoseconds = 0;
-            seconds = data32;
-            break;
-        }
-        case sizeof(uint64_t): {
-            uint64_t data64 = CFSwapInt64BigToHost(*(uint64_t *)self.data.bytes);
-            nanoseconds = data64 >> 34;
-            seconds = data64 & 0x00000003ffffffffL;
-            break;
-        }
-        case 12: {
-            if (OSHostByteOrder() == OSLittleEndian) {
-                uint8_t bytes[12];
-                [self.data getBytes:&bytes[0] length:self.data.length];
-                reverseBytes(&bytes[0], 12);
-                seconds = *(int64_t *)&bytes[0];
-                nanoseconds = *(uint32_t *)(&bytes[0] + sizeof(int64_t));
-            } else {
-                nanoseconds = *(uint32_t *)self.data.bytes;
-                seconds = *(int64_t *)(self.data.bytes + sizeof(uint32_t));
-            }
-            break;
-        }
-        default:
-            [NSException raise:NSInternalInconsistencyException format:@"Encountered unsupported TimeStamp format in MessagePack-data. Size is %li bytes but supported sizes are 32, 64 or 96 bits.", (unsigned long)self.data.length];
-    }
-
-    NSTimeInterval interval = seconds + (nanoseconds / ONE_BILLION);
-    return [NSDate dateWithTimeIntervalSince1970:interval];
+    return data;
 }
 
 @end


### PR DESCRIPTION
Multiball backend has a custom format when sending a date that only contains information about year, month & day. This PR includes an extension that can parse this new format. If we ever wanna send something in this format we can implement serialization later.

The format is very simple:
Byte 0-1: year
Byte 2: month
Byte 3: day